### PR TITLE
モーダルの開閉トランジションの追加

### DIFF
--- a/src/components/atoms/Overlay/index.tsx
+++ b/src/components/atoms/Overlay/index.tsx
@@ -13,6 +13,6 @@ const StyledOverlay = styled.div`
 
 export const Overlay = (): JSX.Element => {
   return (
-      <StyledOverlay />
+    <StyledOverlay />
   )
 }

--- a/src/components/molecules/HalfModal/index.tsx
+++ b/src/components/molecules/HalfModal/index.tsx
@@ -104,7 +104,7 @@ export const HalfModal = ({ isOpen, handleClose }: Props): JSX.Element => {
   //////////////////////////////////////////////////////////////////////////////////////
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    e.preventDefault() 
+    e.preventDefault()
     startTouchYRef.current = e.touches[0].clientY
 
     touchStartPoint.current.x = e.touches[0].clientX
@@ -112,12 +112,12 @@ export const HalfModal = ({ isOpen, handleClose }: Props): JSX.Element => {
   }, [])
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    e.preventDefault() 
+    e.preventDefault()
     currentTouchYRef.current = e.touches[0].clientY
     if (startTouchYRef.current === null || !modalContainerRef.current) return
-    
+
     const dragDistance = currentTouchYRef.current - startTouchYRef.current
-    console.log(modalContainerRef.current.scrollTop)
+
     if (dragDistance < 0) return // 上にスワイプできないようにする
 
     modalContainerRef.current.style.overflowY = "hidden"
@@ -125,10 +125,11 @@ export const HalfModal = ({ isOpen, handleClose }: Props): JSX.Element => {
   }, [])
 
   const handleTouchEnd = useCallback(async (e) => {
-    e.preventDefault() 
+    e.preventDefault()
     if (!modalContainerRef.current || startTouchYRef.current === null) return
     modalContainerRef.current.style.overflowY = "auto"
-    const dragDistance = (currentTouchYRef.current || 0) - startTouchYRef.current
+    const dragDistance =
+      (currentTouchYRef.current || 0) - startTouchYRef.current
 
     const halfModalHeight = modalContainerRef.current.offsetHeight * 0.5
     if (dragDistance > halfModalHeight) {

--- a/src/components/molecules/HalfModal/index.tsx
+++ b/src/components/molecules/HalfModal/index.tsx
@@ -75,8 +75,6 @@ export const HalfModal = ({ isOpen, handleClose }: Props): JSX.Element => {
   // ヘッダーが消えるときに段々と薄くなってなくなるようにして、ヘッダーが固定で表示されるようにする
   const headerRef = useRef<HTMLDivElement | null>(null)
 
-  const touchStartPoint = useRef({ x: 0, y: 0 })
-
   useEffect(() => {
     const handleScroll = () => {
       if (headerRef.current && modalContainerRef.current) {
@@ -106,9 +104,6 @@ export const HalfModal = ({ isOpen, handleClose }: Props): JSX.Element => {
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     e.preventDefault()
     startTouchYRef.current = e.touches[0].clientY
-
-    touchStartPoint.current.x = e.touches[0].clientX
-    touchStartPoint.current.y = e.touches[0].clientY
   }, [])
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {

--- a/src/components/templates/Dashboard/index.tsx
+++ b/src/components/templates/Dashboard/index.tsx
@@ -1,30 +1,42 @@
 "use client"
 import { HalfModal } from "@/components/molecules/HalfModal"
+import { HalfModal2 } from "@/components/molecules/HalfModal/index2"
 import { useModal } from "@/hooks/useModal"
+import useWindowDimensions from "@/hooks/useWindow"
 import React, { useEffect } from "react"
 // import HalfModal from "../HalfModal"
 
 export const DashboardTemplate: React.FC = () => {
   const { isOpen, handleOpen, handleClose } =useModal()
+  const { width, height } = useWindowDimensions()
 
   useEffect(() => {
+    const blockScroll = (e: TouchEvent) => {
+      e.preventDefault()
+    }
+
     if (isOpen) {
       // モーダルが開いているとき、背景のスクロールを無効にする
       document.body.style.overflow = "hidden"
+      // document.body.addEventListener("touchmove", blockScroll, {
+      //   passive: false,
+      // })
     } else {
       // モーダルが閉じているとき、背景のスクロールを有効にする
       document.body.style.overflow = "auto"
+      // document.body.removeEventListener("touchmove", blockScroll)
     }
 
     // コンポーネントがアンマウントされたときに元に戻す
     return () => {
       document.body.style.overflow = "auto"
+      // document.body.removeEventListener("touchmove", blockScroll)
     }
   }, [isOpen])
 
   return (
     <>
-      <div>
+      <div style={{ backgroundColor: "skyblue", height: height, width: width }}>
         <button onClick={handleOpen}>モーダルを開く</button>
       </div>
       <HalfModal isOpen={isOpen} handleClose={handleClose} />

--- a/src/hooks/useWindow.ts
+++ b/src/hooks/useWindow.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react"
+
+const getWindowDimensions = () => {
+  const { innerWidth: width, innerHeight: height } = window
+  return {
+    width,
+    height,
+  }
+}
+
+const useWindowDimensions = () => {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowDimensions(getWindowDimensions)
+    }
+
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
+  }, [])
+
+  return windowDimensions
+}
+export default useWindowDimensions

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,3 @@
+export const delay = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
## 概要
ハーフモーダルの開閉時のトランジションを追加、より快適に使えるように修正

## 変更点
- スワイプして閉じるときに下から上に迫り上がってからハーフモーダルを閉じるようにした
- モーダルのスワイプ領域をヘッダーに修正
ヘッダーとボディーのスワイプタッチ領域は、実機だとスクロールとスワイプがどっちも認識してしまう問題があった。uberイーツのモバイルやyoutubeのモーダルもヘッダーのみタッチ領域にしていたので、同じような仕様にした。


## 効果
よりアプリのハーフモーダルの閉じる機能を体験できる

## 今後
- モーダルを開閉するときに下から上に開く、上から下に閉じるようなアニメーションを追加
- モーダルを閉じるときのトランジションをModalContainerで制御するのではなく、もう一階層上の親要素で管理できるようにする
閉じるときにフッターが残っているようにも見える。またトランジション機能はスタイル定義で管理して、refで極力管理したくない。
